### PR TITLE
fix fast-forward not working with space key

### DIFF
--- a/Opera 11 & 12 (.oex)/includes/scrollbar.js
+++ b/Opera 11 & 12 (.oex)/includes/scrollbar.js
@@ -1124,7 +1124,7 @@ function otherkeyscroll()
 		else if	(e.which === 36) 	scroll_Pos1();
 		else					 	scroll_End();
 	}
-	else if(e.which === 32 && !e.altKey && !e.metaKey && !e.ctrlKey && !target_is_input(e)) // 32 = space bar
+	else if(e.which === 32 && !e.altKey && !e.metaKey && !e.ctrlKey && !target_is_input(e) && window.pageYOffset - window.scrollMaxY > 5) // 32 = space bar
 	{
 		stopEvent();
 		


### PR DESCRIPTION
Title says it all, I used `> 5` so it's more reliable than `!= 0`.
modern scroll never reach 0 on both end at first try.
